### PR TITLE
Use dsl to ensure there are no active connections

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -108,8 +108,8 @@ end
 # network_dirs
 # todo: is this actually necessary?
 
-# 2.9 - Convert to read-write
-logger.puts("Making code read-only...")
+# 2.9 - Convert to writable
+logger.puts("Making code writable...")
 execute 'unlock all the files' do
   command "chmod -R a+w #{APP_DIR}"
 end

--- a/src/stop
+++ b/src/stop
@@ -38,6 +38,13 @@ start_cmds.each do |key, cmd|
 
 end
 
+ensure_socket 'web' do
+  interface 'eth0'
+  port '22'
+  action :no_connections
+  max_checks 300 # todo: make variable
+end
+
 # 2 - Stop narc; Remove sv definitions for narc
 logger.puts("Stopping logging service...")
 service 'narc' do

--- a/src/stop
+++ b/src/stop
@@ -40,7 +40,7 @@ end
 
 ensure_socket 'web' do
   interface 'eth0'
-  port '22'
+  port '8080'
   action :no_connections
   max_checks 300 # todo: make variable
 end


### PR DESCRIPTION
This will prevent the container from being shut down if there is an ongoing large download or other connection to the previous generation (on a re-deploy, scale, etc...)

This requires the dashboard to run the stop hook prior to removing the old container
