### PR TITLE
Handle relative log_watch paths

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -31,15 +31,18 @@ end
 require 'timeout'
 
 # sanitize log watches ()
-true_watches = Array.new
+true_watches = {}
 
 (payload[:log_watches] || {}).each do |key, watch|
   true_path = watch
   if watch[0] != "/"
     true_path = "#{APP_DIR}/#{watch}"
   end
-  true_watches.push(true_path)
+  true_watches[key] = true_path
 end
+
+puts payload[:log_watches]
+puts true_watches
 
 # 1 - Generate narc.conf
 if payload[:logvac_host]

--- a/src/configure
+++ b/src/configure
@@ -48,7 +48,7 @@ if payload[:logvac_host]
     variables ({
       uid: payload[:component][:uid],
       logvac: payload[:logvac_host],
-      watches: payload[:log_watches] || {},
+      watches: true_watches,
       start_cmds: start_cmds
     })
   end

--- a/src/configure
+++ b/src/configure
@@ -30,6 +30,17 @@ end
 
 require 'timeout'
 
+# sanitize log watches ()
+true_watches = Array.new
+
+(payload[:log_watches] || {}).each do |key, watch|
+  true_path = watch
+  if watch[0] != "/"
+    true_path = "#{APP_DIR}/#{watch}"
+  end
+  true_watches.push(true_path)
+end
+
 # 1 - Generate narc.conf
 if payload[:logvac_host]
   logger.puts("Configuring logging...")
@@ -67,16 +78,12 @@ end
 logger.puts("Ensuring required directories exist...")
 
 # log_watches
-(payload[:log_watches] || {}).each do |key, watch|
-  true_path = watch
-  if watch[0] != "/"
-    true_path = "#{APP_DIR}/#{watch}"
-  end
-  if not ::File.exists? "#{true_path}"
+true_watches.each do |key, watch|
+  if not ::File.exists? "#{watch}"
     
-    puts "#{true_path}"
-    puts File.expand_path("..", "#{true_path}")
-    parent = File.expand_path("..", "#{true_path}")
+    puts "#{watch}"
+    puts File.expand_path("..", "#{watch}")
+    parent = File.expand_path("..", "#{watch}")
     
     # create the parent directory
     directory parent do
@@ -86,7 +93,7 @@ logger.puts("Ensuring required directories exist...")
     end
     
     # create the log_watch file
-    file "#{true_path}" do
+    file "#{watch}" do
       owner 'gonano'
       group 'gonano'
       mode  0644
@@ -173,13 +180,9 @@ end
 
 # 6 - Unset log_watches
 logger.puts("Making log_watches writable...")
-(payload[:log_watches] || {}).each do |key, watch|
-  true_path = watch
-  if watch[0] != "/"
-    true_path = "#{APP_DIR}/#{watch}"
-  end
+true_watches.each do |key, watch|
   execute "undo read-only on #{watch}" do
-    command "chmod -R +w #{true_path}"
+    command "chmod -R +w #{watch}"
   end
 end
 

--- a/src/lib/engine.rb
+++ b/src/lib/engine.rb
@@ -55,7 +55,7 @@ module Nanobox
 
     def run_deploy_hook(index, cmd, cuid, muid, type, logger, bubble=false)
       begin
-        Timeout::timeout(payload[:deploy_hook_timeout] || 60) do
+        Timeout::timeout(payload[:hook_timeout] || 300) do
           logger.puts("Starting: #{cmd}", Nanobox::Logvac::INFO, "#{cuid}.#{muid}[#{type}#{index + 1}]")
           execute "#{type}#{index + 1}: #{cmd}" do
             command "siphon --prefix '' -- bash -i -l -c \"#{escape cmd}\""

--- a/src/templates/narc.conf.erb
+++ b/src/templates/narc.conf.erb
@@ -53,5 +53,9 @@ stream-priority error
 stream <%= key %>[daemon] /var/log/gonano/<%= key %>/current
 <% end -%>
 <% watches.each do |key, path| -%>
+  <% if path[0] == "/" -%>
 stream <%= key %> <%= path %>
+  <% else -%>
+stream <%= key %> /app/<%= path %>
+  <% end -%>
 <% end -%>

--- a/src/templates/narc.conf.erb
+++ b/src/templates/narc.conf.erb
@@ -53,9 +53,5 @@ stream-priority error
 stream <%= key %>[daemon] /var/log/gonano/<%= key %>/current
 <% end -%>
 <% watches.each do |key, path| -%>
-  <% if path[0] == "/" -%>
 stream <%= key %> <%= path %>
-  <% else -%>
-stream <%= key %> /app/<%= path %>
-  <% end -%>
 <% end -%>


### PR DESCRIPTION
Narc wasn't watching them, but they were handled elsewhere. Sanitize them once and use everywhere. 

This definitely needs review as I didn't test it nor claim to be a ruby pro.