### PR TITLE
Use alternate string designator to escape command string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - VERSION=latest
 
 before_install:
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - docker version
   - docker network create --driver=bridge --subnet=192.168.0.0/16 --opt="com.docker.network.driver.mtu=1450" --opt="com.docker.network.bridge.name=redd0" nanobox
   - ifconfig
@@ -15,12 +16,8 @@ before_install:
 script:
   - make test-${VERSION}
 
-jobs:
-  include:
-    - stage: publish
-      script:
-        - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-        - 'if [ "$BRANCH" == "master" ]; 
-            then make;
-            curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Travis-API-Version: 3" -H "Authorization: token ${TRAVIS_TOKEN}" -d "{\"request\":{\"branch\":\"master\"}}" https://api.travis-ci.org/repo/nanobox-io%2Fnanobox-docker-code/requests; 
-          fi'
+after_success:
+  - 'if [ "$BRANCH" == "master" ];
+      then make;
+      curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Travis-API-Version: 3" -H "Authorization: token ${TRAVIS_TOKEN}" -d "{\"request\":{\"branch\":\"master\"}}" https://api.travis-ci.org/repo/nanobox-io%2Fnanobox-docker-code/requests;
+    fi'

--- a/src/configure
+++ b/src/configure
@@ -84,18 +84,18 @@ logger.puts("Ensuring required directories exist...")
 # log_watches
 true_watches.each do |key, watch|
   if not ::File.exists? "#{watch}"
-    
+
     puts "#{watch}"
     puts File.expand_path("..", "#{watch}")
     parent = File.expand_path("..", "#{watch}")
-    
+
     # create the parent directory
     directory parent do
       owner 'gonano'
       group 'gonano'
       recursive true
     end
-    
+
     # create the log_watch file
     file "#{watch}" do
       owner 'gonano'
@@ -365,6 +365,7 @@ if payload[:member][:uid] == 1 && ! payload[:cron_jobs].nil?
         component_uid: payload[:component][:uid],
         member_uid: payload[:member][:uid],
         logvac_host: payload[:logvac_host],
+        name: job[:id],
         command: job[:command],
         cron_id: id + 1,
         app_dir: APP_DIR

--- a/src/templates/cron.erb
+++ b/src/templates/cron.erb
@@ -13,14 +13,14 @@ require 'hookit/setup'
 logger = RemoteSyslogLogger.new("<%= logvac_host %>", 514)
 
 begin
-  logger.add(Logger::INFO, "Starting: <%= command %>", "<%= component_uid %>.<%= member_uid %>[cron<%= cron_id %>]")
-  execute "<%= command %>" do
-    command "<%= command %>"
+  logger.add(Logger::INFO, "Starting: <%= name %>", "<%= component_uid %>.<%= member_uid %>[cron<%= cron_id %>]")
+  execute "<%= name %>" do
+    command %{<%= command %>}
     cwd "<%= app_dir %>"
     user 'gonano'
     on_data {|data| logger.add(Logger::INFO, data, "<%= component_uid %>.<%= member_uid %>[cron<%= cron_id %>]")}
   end
-  logger.add(Logger::INFO, "Finished: <%= command %>", "<%= component_uid %>.<%= member_uid %>[cron<%= cron_id %>]")
+  logger.add(Logger::INFO, "Finished: <%= name %>", "<%= component_uid %>.<%= member_uid %>[cron<%= cron_id %>]")
 rescue Hookit::Error::UnexpectedExit
   logger.add(Logger::ERROR, "There was an unexpected exit from the cron", "<%= component_uid %>.<%= member_uid %>[cron<%= cron_id %>]")
 end


### PR DESCRIPTION
Also use the job's name rather than its command to identify it in log entries.

And fix the `.travis.yml` configuration so the actual tests actually run.